### PR TITLE
플레이어 인풋 시스템 개선

### DIFF
--- a/Assets/Scripts/Core/Extensions.meta
+++ b/Assets/Scripts/Core/Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4bb431c155b69416b89d037aa59df620
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Extensions/Vector3Extensions.cs
+++ b/Assets/Scripts/Core/Extensions/Vector3Extensions.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SuraSang
+{
+    public static class Vector3Extentions
+    {
+        public static Vector3 InputToTransformSpace(Vector2 input, Transform transform)
+        {
+            var foward = transform.forward;
+            var right = transform.right;
+            foward.y = 0;
+            right.y = 0;
+            foward.Normalize();
+            right.Normalize();
+
+            var fowardReVerticalInput = input.y * foward;
+            var rightRelHorizontalInput = input.x * right;
+
+            return fowardReVerticalInput + rightRelHorizontalInput;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Extensions/Vector3Extensions.cs.meta
+++ b/Assets/Scripts/Core/Extensions/Vector3Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1ce3735a05a54d739f51e2fbd165d7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Player.Absorb.cs
+++ b/Assets/Scripts/Player/Player.Absorb.cs
@@ -29,8 +29,6 @@ namespace SuraSang
 
         private void InitAbsorb()
         {
-            SetAction(ButtonActions.Absorb, OnAbsorb);
-
             _defaultMaterial = GetComponent<Material>();
             _defaultMaterial = gameObject.GetComponent<Renderer>().material;
         }
@@ -48,7 +46,12 @@ namespace SuraSang
             }
         }
 
-        public Collider[] FindViewTargets()
+        public void SetAbsorbAction()
+        {
+            SetAction(ButtonActions.Absorb, OnAbsorb);
+        }
+        
+        private Collider[] FindViewTargets()
         {
             _hitTargetContainer.Clear();
 

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -111,17 +111,7 @@ namespace SuraSang
 
         public Vector3 InputToCameraSpace(Vector2 input)
         {
-            var foward = _cameraTransform.forward;
-            var right = _cameraTransform.right;
-            foward.y = 0;
-            right.y = 0;
-            foward.Normalize();
-            right.Normalize();
-
-            var fowardReVerticalInput = input.y * foward;
-            var rightRelHorizontalInput = input.x * right;
-
-            return fowardReVerticalInput + rightRelHorizontalInput;
+            return Vector3Extentions.InputToTransformSpace(input, _cameraTransform);
         }
 
         public void LookVector(Vector3 dir)

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -27,8 +27,6 @@ namespace SuraSang
         private CharacterActions _inputActions;
         private InputAction _moveInputAction;
 
-
-        public bool isWPressed;
         public Vector3 MoveDir { get; set; }
 
 
@@ -71,16 +69,6 @@ namespace SuraSang
             var moveInput = _moveInputAction.ReadValue<Vector2>();
 
             OnMove?.Invoke(moveInput);
-
-            if (moveInput.x == 0.0f && moveInput.y == 1.0f)
-            {
-                isWPressed = true;
-            }
-            else
-            {
-                isWPressed = false;
-            }
-
         }
 
         private void OnEnable()

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -21,6 +21,7 @@ namespace SuraSang
     {
         // 벡터를 넘겨주기 위해 move만 따로 처리
         public UnityAction<Vector2> OnMove { get; set; }
+        private Dictionary<ButtonActions, InputAction> _buttonActions;
         private Dictionary<ButtonActions, UnityAction<bool>> _buttonEvents;
 
         private CharacterActions _inputActions;
@@ -33,32 +34,36 @@ namespace SuraSang
 
         private void InitInputs()
         {
+            _buttonActions = new Dictionary<ButtonActions, InputAction>();
             _buttonEvents = new Dictionary<ButtonActions, UnityAction<bool>>();
 
             _inputActions = new global::CharacterActions();
             _moveInputAction = _inputActions.Player.Move;
 
+            _buttonActions.Add(ButtonActions.Run, _inputActions.Player.Run);
             _inputActions.Player.Run.performed += (x) => GetAction(ButtonActions.Run)?.Invoke(true);
             _inputActions.Player.Run.canceled += (x) => GetAction(ButtonActions.Run)?.Invoke(false);
 
+            _buttonActions.Add(ButtonActions.Jump, _inputActions.Player.Jump);
             _inputActions.Player.Jump.started += (x) => GetAction(ButtonActions.Jump)?.Invoke(true);
             _inputActions.Player.Jump.canceled += (x) => GetAction(ButtonActions.Jump)?.Invoke(false);
 
+            _buttonActions.Add(ButtonActions.Crouch, _inputActions.Player.Crouch);
             _inputActions.Player.Crouch.performed += (x) => GetAction(ButtonActions.Crouch)?.Invoke(true);
             _inputActions.Player.Crouch.canceled += (x) => GetAction(ButtonActions.Crouch)?.Invoke(false);
 
+            _buttonActions.Add(ButtonActions.Catch, _inputActions.Player.Catch);
             _inputActions.Player.Catch.performed += (x) => GetAction(ButtonActions.Catch)?.Invoke(true);
             _inputActions.Player.Catch.canceled += (x) => GetAction(ButtonActions.Catch)?.Invoke(false);
 
 
+            _buttonActions.Add(ButtonActions.Hold, _inputActions.Player.Hold);
             _inputActions.Player.Hold.performed += (x) => GetAction(ButtonActions.Hold)?.Invoke(true);
             _inputActions.Player.Hold.canceled += (x) => GetAction(ButtonActions.Hold)?.Invoke(false);
 
-            _inputActions.Player.Hold.performed += (x) => GetAction(ButtonActions.Absorb)?.Invoke(true);
-            _inputActions.Player.Hold.canceled += (x) => GetAction(ButtonActions.Absorb)?.Invoke(false);
-
-            _inputActions.Player.Move.performed += (x) => isWPressed = true;
-            _inputActions.Player.Move.canceled += (x) => isWPressed = false;
+            _buttonActions.Add(ButtonActions.Absorb, _inputActions.Player.Absorb);
+            _inputActions.Player.Absorb.performed += (x) => GetAction(ButtonActions.Absorb)?.Invoke(true);
+            _inputActions.Player.Absorb.canceled += (x) => GetAction(ButtonActions.Absorb)?.Invoke(false);
         }
 
         private void UpdateInputs()
@@ -106,6 +111,11 @@ namespace SuraSang
             else
             {
                 _buttonEvents[type] = action;
+            }
+            
+            if (_buttonActions.TryGetValue(type, out var input))
+            {
+                action?.Invoke(input.IsPressed());
             }
         }
 

--- a/Assets/Scripts/Player/PlayerState/PlayerMoveFalling.cs
+++ b/Assets/Scripts/Player/PlayerState/PlayerMoveFalling.cs
@@ -8,11 +8,15 @@ namespace SuraSang
     {
         // TODO : 여기서 메달리기 상태로 이어지게 만들면 될 듯
 
+        private bool _isHolding;
+        
         public PlayerMoveFalling(CharacterMove characterMove) : base(characterMove) { }
 
         public override void InitializeState()
         {
             _player.OnMove = OnMove;
+            
+            _player.SetAction(ButtonActions.Hold, isOn => _isHolding = isOn);
         }
 
         public override void UpdateState() { }
@@ -39,7 +43,7 @@ namespace SuraSang
             {
                 _characterMove.ChangeState(new PlayerMoveGrounded(_characterMove));
             }
-            else if (_player.IsEdgeDetected() && !_controller.isGrounded)
+            else if (_player.IsEdgeDetected() && _isHolding && !_controller.isGrounded)
             {
                 _characterMove.ChangeState(new PlayerMoveHolding(_characterMove));
             }

--- a/Assets/Scripts/Player/PlayerState/PlayerMoveGrounded.cs
+++ b/Assets/Scripts/Player/PlayerState/PlayerMoveGrounded.cs
@@ -18,6 +18,7 @@ namespace SuraSang
         public override void InitializeState()
         {
             _player.OnMove = OnMove;
+            _player.SetAbsorbAction();
 
             _player.SetAction(ButtonActions.Run, OnRun);
             //_characterMove.SetAction(ButtonActions.Crouch, OnCrouch);

--- a/Assets/Scripts/Player/PlayerState/PlayerMoveJumping.cs
+++ b/Assets/Scripts/Player/PlayerState/PlayerMoveJumping.cs
@@ -9,6 +9,7 @@ namespace SuraSang
         public PlayerMoveJumping(CharacterMove characterMove) : base(characterMove) { }
 
         private bool _isJumpEnd = false;
+        private bool _isHolding;
         private float _jumpStartTime;
 
         public override void InitializeState()
@@ -16,6 +17,7 @@ namespace SuraSang
             _jumpStartTime = Time.time;
             _player.OnMove = OnMove;
 
+            _player.SetAction(ButtonActions.Hold, isOn => _isHolding = isOn);
             _player.SetAction(ButtonActions.Jump, OnJump);
 
 
@@ -45,10 +47,6 @@ namespace SuraSang
             {
                 y = _player.JumpPower;
             }
-            else if (_player.IsEdgeDetected())
-            {
-                _characterMove.ChangeState(new PlayerMoveHolding(_characterMove));
-            }
             else
             {
                 y -= _player.Gravity * Time.deltaTime;
@@ -58,6 +56,11 @@ namespace SuraSang
                 {
                     _characterMove.ChangeState(new PlayerMoveFalling(_characterMove));
                 }
+            }
+            
+            if (_player.IsEdgeDetected() && _isHolding)
+            {
+                _characterMove.ChangeState(new PlayerMoveHolding(_characterMove));
             }
 
             dir.y = 0;


### PR DESCRIPTION
**벡터 익스텐션 추가**

별건 아니고 벡터 관련해서 여러 곳에서 쓸 수 있을 함수들을 모아두는 그런 스테틱 클래스입니다.
인풋을 특정 트랜스폼 기준으로 돌리는 함수만 들어있어요
(지금은 Player.Input과 Holding상태에서 사용합니다.)

**상태 넘어갈 때 키 갱신하기**

새로 액션을 등록할 때
등록하려는 액션을 한번 호출해주는 기능 추가했습니다.

**흡수 액션 설정**

흡수가 고장나 있었네요
grounded 상태일때 흡수 액션 설정하는 기능 추가했습니다.


**홀딩 상태 갈아엎기**

비오님 죄송합니다 ㅠㅠ
어떻게 하다보니 완전 갈아엎어졌네요.

일단 위에 상태 넘어갈 때 키 갱신하는 기능 덕분에
Jumping 상태와 Falling 상태에서 자연스럽게 Holding 상태로 넘어가는 기능 추가했구요

위에 벡터 익스텐션에 넣어둔 InputToTransformSpace 사용해서
좌우키 사용해 좌 우 이동하는 기능까지 제작해뒀습니다.

이제 위로 올라가는 기능이랑
어느정도 폴리싱만 하면 될 듯 하네요 (아직 holding 이동 속도 적용 안함)