### PR TITLE
통나무 버그 수정, 분노 수정

### DIFF
--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleLog.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleLog.cs
@@ -19,6 +19,11 @@ namespace SuraSang
 
         public override void OnNotify(PuzzleContext context)
         {
+            if (!_rigidbody.isKinematic)
+            {
+                return;
+            }
+
             base.OnNotify(context);
 
             if (_context == null)


### PR DESCRIPTION
분노 충돌체크 방식 cast에서 overlap으로 변경

통나무 재사용 못하게 막음
