### PR TITLE
CameraSwitcher 구현

### DIFF
--- a/Assets/Scenes/1Stage_HB.unity
+++ b/Assets/Scenes/1Stage_HB.unity
@@ -1,0 +1,303 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &401266822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 401266825}
+  - component: {fileID: 401266824}
+  - component: {fileID: 401266823}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &401266823
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401266822}
+  m_Enabled: 1
+--- !u!20 &401266824
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401266822}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &401266825
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 401266822}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1222939906
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1222939908}
+  - component: {fileID: 1222939907}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1222939907
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1222939906}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1222939908
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1222939906}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/Assets/Scenes/1Stage_HB.unity.meta
+++ b/Assets/Scenes/1Stage_HB.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa343b0771cd91f4a8ecfa0b91afd0ff
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Camera.meta
+++ b/Assets/Scripts/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc1f92ba8f57e3e4cbcaf7a8eef84eab
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Camera/CameraRegister.cs
+++ b/Assets/Scripts/Camera/CameraRegister.cs
@@ -1,0 +1,19 @@
+using Cinemachine;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SuraSang
+{
+    public class CameraRegister : MonoBehaviour
+    {
+        private void OnEnable()
+        {
+            CameraSwitcher.RegisterCamera(GetComponent<CinemachineVirtualCamera>());
+        }
+        private void OnDisable()
+        {
+            CameraSwitcher.UnregisterCamera(GetComponent<CinemachineVirtualCamera>());
+        }
+    }
+}

--- a/Assets/Scripts/Camera/CameraRegister.cs.meta
+++ b/Assets/Scripts/Camera/CameraRegister.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25c2677fbaa758445b84bb85555b7b06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Camera/CameraSwitcher.cs
+++ b/Assets/Scripts/Camera/CameraSwitcher.cs
@@ -1,0 +1,40 @@
+using Cinemachine;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace SuraSang
+{
+    public class CameraSwitcher : MonoBehaviour
+    {
+        static List<CinemachineVirtualCamera> _cameras = new List<CinemachineVirtualCamera>();
+        public static CinemachineVirtualCamera ActiveCamera = null;
+
+        public static void RegisterCamera(CinemachineVirtualCamera camera)
+        {
+            _cameras.Add(camera);
+        }
+
+        public static void UnregisterCamera(CinemachineVirtualCamera camera)
+        {
+            _cameras.Remove(camera);
+        }
+
+        public static void SwitchCamera(CinemachineVirtualCamera camera)
+        {
+            camera.Priority = 10;
+            ActiveCamera = camera;
+
+            foreach (CinemachineVirtualCamera i in _cameras)
+            {
+                if (i != camera && i.Priority != 0) i.Priority = 0;
+            }
+        }
+
+        public static bool IsActiveCamera(CinemachineVirtualCamera camera)
+        {
+            return camera == ActiveCamera;
+        }
+    }
+}

--- a/Assets/Scripts/Camera/CameraSwitcher.cs
+++ b/Assets/Scripts/Camera/CameraSwitcher.cs
@@ -8,8 +8,8 @@ namespace SuraSang
 {
     public class CameraSwitcher : MonoBehaviour
     {
-        static List<CinemachineVirtualCamera> _cameras = new List<CinemachineVirtualCamera>();
-        public static CinemachineVirtualCamera ActiveCamera = null;
+        private static List<CinemachineVirtualCamera> _cameras = new List<CinemachineVirtualCamera>();
+        private static CinemachineVirtualCamera _activeCamera = null;
 
         public static void RegisterCamera(CinemachineVirtualCamera camera)
         {
@@ -24,7 +24,7 @@ namespace SuraSang
         public static void SwitchCamera(CinemachineVirtualCamera camera)
         {
             camera.Priority = 10;
-            ActiveCamera = camera;
+            _activeCamera = camera;
 
             foreach (CinemachineVirtualCamera i in _cameras)
             {
@@ -34,7 +34,7 @@ namespace SuraSang
 
         public static bool IsActiveCamera(CinemachineVirtualCamera camera)
         {
-            return camera == ActiveCamera;
+            return camera == _activeCamera;
         }
     }
 }

--- a/Assets/Scripts/Camera/CameraSwitcher.cs.meta
+++ b/Assets/Scripts/Camera/CameraSwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc68cfbfa6c84884cb15a952c7511119
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Camera/CameraTriggerVolume.cs
+++ b/Assets/Scripts/Camera/CameraTriggerVolume.cs
@@ -12,8 +12,8 @@ namespace SuraSang
         [SerializeField] private CinemachineVirtualCamera _camera;
         [SerializeField] private Vector3 _boxSize;
 
-        BoxCollider _box;
-        Rigidbody _rb;
+        private BoxCollider _box;
+        private Rigidbody _rb;
 
 
         private void Awake()
@@ -37,7 +37,7 @@ namespace SuraSang
         {
             if (other.gameObject.CompareTag("Player"))
             {
-                if (CameraSwitcher.ActiveCamera != _camera) CameraSwitcher.SwitchCamera(_camera);
+                if (!CameraSwitcher.IsActiveCamera(_camera)) CameraSwitcher.SwitchCamera(_camera);
             }
         }
     }

--- a/Assets/Scripts/Camera/CameraTriggerVolume.cs
+++ b/Assets/Scripts/Camera/CameraTriggerVolume.cs
@@ -1,0 +1,44 @@
+using Cinemachine;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing.Text;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace SuraSang
+{
+    public class CameraTriggerVolume : MonoBehaviour
+    {
+        [SerializeField] private CinemachineVirtualCamera _camera;
+        [SerializeField] private Vector3 _boxSize;
+
+        BoxCollider _box;
+        Rigidbody _rb;
+
+
+        private void Awake()
+        {
+            _box = GetComponent<BoxCollider>();
+            _rb = GetComponent<Rigidbody>();
+
+            _box.isTrigger = true;
+            _box.size = _boxSize;
+
+            _rb.isKinematic = true;
+        }
+
+        private void OnDrawGizmos()
+        {
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireCube(transform.position, _boxSize);
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.gameObject.CompareTag("Player"))
+            {
+                if (CameraSwitcher.ActiveCamera != _camera) CameraSwitcher.SwitchCamera(_camera);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Camera/CameraTriggerVolume.cs.meta
+++ b/Assets/Scripts/Camera/CameraTriggerVolume.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b6008a1f6fdec149b6d9b4afe786953
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Script/Camera**
1. CameraRegister
    - Cineamchine 카메라가 자동으로 Switcher에서 관리하는 List에 추가하기 위해 사용합니다.
2. CameraSwitcher
    - Cinemachine 카메라를 TriggerVolume에 따라 교체해주는 메인 코어입니다.
3. CameraTriggerVolume
    - Cinemachine 카메라가 교체되거나, 이동할 수 있는 영역을 제한하는 Volume 스크립트 입니다.
    - 사용할 Camera를 지정할 수 있고 BoxSize를 통해 영역을 생성하면 알아서 콜라이더가 잡힙니다.

![화면 캡처 2022-10-17 012349](https://user-images.githubusercontent.com/20338405/196046603-85a8553b-f747-40b9-9cda-3713ad2a0990.png)
　
　
　
**Scene/1Stage_HB**
- CameraSwitcher를 테스트 하기 위해 생성했지만, 이후 제가 만드는 기능 테스트는 전부 이 씬에서 할 예정입니다.

![GIF 2022-10-17 오전 1-14-45](https://user-images.githubusercontent.com/20338405/196046699-49847486-c822-48c8-8aa6-f1e3a05cdeae.gif)
