### PR TITLE
트램펄린 추가

### DIFF
--- a/Assets/Scripts/Core/CharacterMove/CharacterMove.cs
+++ b/Assets/Scripts/Core/CharacterMove/CharacterMove.cs
@@ -43,5 +43,7 @@ namespace SuraSang
 
             transform.rotation = Quaternion.Slerp(transform.rotation, target, _rotationSpeed * Time.deltaTime);
         }
+
+        public abstract void MovePosition(Vector3 pos);
     }
 }

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -35,5 +35,11 @@ namespace SuraSang
         {
             // TODO 공용으로 사용하는 상태의 경우 다음 상태를 어케 해야할지?
         }
+
+        public override void MovePosition(Vector3 pos)
+        {
+            transform.position = pos;
+            Agent.Move(pos);
+        }
     }
 }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -91,6 +91,13 @@ namespace SuraSang
             }
         }
 
+        public override void MovePosition(Vector3 pos)
+        {
+            Controller.enabled = false;
+            transform.position = pos;
+            Controller.enabled = true;
+        }
+
         //private void OnControllerColliderHit(ControllerColliderHit hit)
         //{
         //    var rig = hit.collider.attachedRigidbody;

--- a/Assets/Scripts/Player/PlayerState/PlayerMoveJumping.cs
+++ b/Assets/Scripts/Player/PlayerState/PlayerMoveJumping.cs
@@ -8,6 +8,12 @@ namespace SuraSang
     {
         public PlayerMoveJumping(CharacterMove characterMove) : base(characterMove) { }
 
+        public PlayerMoveJumping(CharacterMove characterMove, Vector3 overrideJumpDir) : base(characterMove)
+        {
+            _overrideJumpDir = overrideJumpDir;
+        }
+
+        private Vector3 _overrideJumpDir = Vector3.zero;
         private bool _isJumpEnd = false;
         private bool _isHolding;
         private float _jumpStartTime;
@@ -21,9 +27,16 @@ namespace SuraSang
             _player.SetAction(ButtonActions.Jump, OnJump);
             _player.Animator.SetBool("IsJumping", true);
 
-            var dir = _player.MoveDir;
-            dir.y = _player.PlayerData.JumpPower;
-            _player.MoveDir = dir;
+            if (_overrideJumpDir == Vector3.zero)
+            {
+                var dir = _player.MoveDir;
+                dir.y = _player.PlayerData.JumpPower;
+                _player.MoveDir = dir;
+            }
+            else
+            {
+                _player.MoveDir = _overrideJumpDir;
+            }
         }
 
         public override void UpdateState() { }
@@ -60,7 +73,7 @@ namespace SuraSang
                     _characterMove.ChangeState(new PlayerMoveFalling(_characterMove));
                 }
             }
-            
+
             if (_player.IsEdgeDetected() && _isHolding)
             {
                 _characterMove.ChangeState(new PlayerMoveHolding(_characterMove));

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor.meta
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 316020de9c8574f3f90b2145ce8e0080
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -20,11 +20,6 @@ namespace SuraSang
 
         void OnSceneGUI()
         {
-            Vector3 GetVector(float radians)
-            {
-                return new Vector3(Mathf.Cos(radians), 0, Mathf.Sin(radians));
-            }
-
             _component = target as PuzzleTrampolin;
 
             // 거리
@@ -37,50 +32,63 @@ namespace SuraSang
                 Quaternion.Euler(0, -_component.StartAngle + 90, 0), 3, Handles.ConeHandleCap, 1);
 
 
+            //최소 높이
+            Handles.color = Color.white;
+
+            handlePos = _component.JumpPoint.position + Vector3.up * _component.MinHeight;
+
+            _component.MinHeight = Handles.ScaleValueHandle(_component.MinHeight, handlePos,
+                Quaternion.Euler(90, 0, 0), 3, Handles.ConeHandleCap, 1);
+
+            DrawArcs(_component.MinHeight);
+
             // 높이 (그냥 표시용)
             var gravity = _component._playerData.Gravity * _component._playerData.FallingGravityMultiplier;
-            
+
             for (int i = 0; i < _component.DebugHeight.Length; i++)
             {
-                Random.InitState(i);
-                Handles.color = new Color(Random.Range(0.25f, 0.75f), Random.Range(0.25f, 0.75f), Random.Range(0.25f, 0.75f), 1);
-                
+                Handles.color = Color.HSVToRGB((float)i / _component.DebugHeight.Length, 1, 1);
+
                 handlePos = _component.JumpPoint.position + Vector3.up * _component.DebugHeight[i];
 
                 Handles.Label(handlePos, $"높이 {i} : {_component.DebugHeight[i]}");
-                
+
                 _component.DebugHeight[i] = Handles.ScaleValueHandle(_component.DebugHeight[i], handlePos,
                     Quaternion.Euler(-90, 0, 0), 3, Handles.SphereHandleCap, 1);
 
-                
-                float vel = Mathf.Sqrt(gravity * 2 * _component.DebugHeight[i]) * _component.PowerReduction;
-
-                var plusAngle = 360f / _dirCount;
-
-                for (int j = 0; j < _dirCount; j++)
-                {
-                    var dir = GetVector((_component.StartAngle + j * plusAngle) * Mathf.Deg2Rad).normalized * 3;
-                    DrawArc(dir, vel);
-                }
-                
+                DrawArcs(_component.DebugHeight[i]);
             }
         }
 
-        private void DrawArc(Vector3 dir, float jumpPower)
+        private Vector3 GetVector(float radians)
         {
-            var velocity = dir * _component.JumpVelocity;
-            velocity.y = jumpPower;
+            return new Vector3(Mathf.Cos(radians), 0, Mathf.Sin(radians));
+        }
 
-            var pos = _component.JumpPoint.position;
-            
-            for (int i = 1; i < _debugLineLength + 1; i++)
+        private void DrawArcs(float height)
+        {
+            var gravity = _component._playerData.Gravity * _component._playerData.FallingGravityMultiplier;
+            float vel = Mathf.Sqrt(gravity * 2 * height) * _component.PowerReduction;
+
+            var plusAngle = 360f / _dirCount;
+
+            for (int j = 0; j < _dirCount; j++)
             {
-                velocity.y -= (_component._playerData.Gravity *
-                               (velocity.y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
-                velocity.y = Mathf.Max(velocity.y, -_component._playerData.GravityLimit);
+                var dir = GetVector((_component.StartAngle + j * plusAngle) * Mathf.Deg2Rad).normalized * 3;
+                var velocity = dir * _component.JumpVelocity;
+                velocity.y = vel;
 
-                Handles.DrawLine(pos, pos + velocity * _delta, 3);
-                pos += velocity * _delta;
+                var pos = _component.JumpPoint.position;
+
+                for (int i = 1; i < _debugLineLength + 1; i++)
+                {
+                    velocity.y -= (_component._playerData.Gravity *
+                                   (velocity.y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
+                    velocity.y = Mathf.Max(velocity.y, -_component._playerData.GravityLimit);
+
+                    Handles.DrawLine(pos, pos + velocity * _delta, 3);
+                    pos += velocity * _delta;
+                }
             }
         }
     }

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -20,6 +20,8 @@ namespace SuraSang
 
         void OnSceneGUI()
         {
+            EditorGUI.BeginChangeCheck();
+
             _component = target as PuzzleTrampolin;
 
             // 거리
@@ -30,7 +32,6 @@ namespace SuraSang
 
             _component.JumpVelocity = Handles.ScaleValueHandle(_component.JumpVelocity, handlePos,
                 Quaternion.Euler(0, -_component.StartAngle + 90, 0), 3, Handles.ConeHandleCap, 1);
-
 
             //최소 높이
             Handles.color = Color.white;
@@ -57,6 +58,12 @@ namespace SuraSang
                     Quaternion.Euler(-90, 0, 0), 3, Handles.SphereHandleCap, 1);
 
                 DrawArcs(_component.DebugHeight[i]);
+            }
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorUtility.SetDirty(target);
+                Undo.RecordObject(target, "Trampolin");
             }
         }
 

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace SuraSang
+{
+    [CustomEditor(typeof(PuzzleTrampolin))]
+    public class ExampleInspector : Editor
+    {
+        private const int _dirCount = 6;
+
+        private const float _debugLineLength = 50;
+        private const float _delta = 0.01f;
+
+        private const float _handleSize = 3;
+
+        private PuzzleTrampolin _component;
+
+
+        void OnSceneGUI()
+        {
+            Vector3 GetVector(float radians)
+            {
+                return new Vector3(Mathf.Cos(radians), 0, Mathf.Sin(radians));
+            }
+
+            _component = target as PuzzleTrampolin;
+
+            // 거리
+            Handles.color = Color.red;
+
+            var handlePos = _component.JumpPoint.position +
+                            GetVector(_component.StartAngle * Mathf.Deg2Rad) * _handleSize;
+
+            _component.JumpVelocity = Handles.ScaleValueHandle(_component.JumpVelocity, handlePos,
+                Quaternion.Euler(0, -_component.StartAngle + 90, 0), 3, Handles.ConeHandleCap, 1);
+
+
+            // 높이 (그냥 표시용)
+            var gravity = _component._playerData.Gravity * _component._playerData.FallingGravityMultiplier;
+            
+            for (int i = 0; i < _component.DebugHeight.Length; i++)
+            {
+                Random.InitState(i);
+                Handles.color = new Color(Random.Range(0.25f, 0.75f), Random.Range(0.25f, 0.75f), Random.Range(0.25f, 0.75f), 1);
+                
+                handlePos = _component.JumpPoint.position + Vector3.up * _component.DebugHeight[i];
+
+                Handles.Label(handlePos, $"높이 {i} : {_component.DebugHeight[i]}");
+                
+                _component.DebugHeight[i] = Handles.ScaleValueHandle(_component.DebugHeight[i], handlePos,
+                    Quaternion.Euler(-90, 0, 0), 3, Handles.SphereHandleCap, 1);
+
+                
+                float vel = Mathf.Sqrt(gravity * 2 * _component.DebugHeight[i]) * _component.PowerReduction;
+
+                var plusAngle = 360f / _dirCount;
+
+                for (int j = 0; j < _dirCount; j++)
+                {
+                    var dir = GetVector((_component.StartAngle + j * plusAngle) * Mathf.Deg2Rad).normalized * 3;
+                    DrawArc(dir, vel);
+                }
+                
+            }
+        }
+
+        private void DrawArc(Vector3 dir, float jumpPower)
+        {
+            var velocity = dir * _component.JumpVelocity;
+            velocity.y = jumpPower;
+
+            var pos = _component.JumpPoint.position;
+            
+            for (int i = 1; i < _debugLineLength + 1; i++)
+            {
+                velocity.y -= (_component._playerData.Gravity *
+                               (velocity.y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
+                velocity.y = Mathf.Max(velocity.y, -_component._playerData.GravityLimit);
+
+                Handles.DrawLine(pos, pos + velocity * _delta, 3);
+                pos += velocity * _delta;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -86,7 +86,7 @@ namespace SuraSang
                                    (velocity.y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
                     velocity.y = Mathf.Max(velocity.y, -_component._playerData.GravityLimit);
 
-                    Handles.DrawLine(pos, pos + velocity * _delta, 3);
+                    Handles.DrawDottedLine(pos, pos + velocity * _delta, 3);
                     pos += velocity * _delta;
                 }
             }

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -74,7 +74,7 @@ namespace SuraSang
 
             for (int j = 0; j < _dirCount; j++)
             {
-                var dir = GetVector((_component.StartAngle + j * plusAngle) * Mathf.Deg2Rad).normalized * 3;
+                var dir = GetVector((_component.StartAngle + j * plusAngle) * Mathf.Deg2Rad).normalized;
                 var velocity = dir * _component.JumpVelocity;
                 velocity.y = vel;
 
@@ -82,9 +82,16 @@ namespace SuraSang
 
                 for (int i = 1; i < _debugLineLength + 1; i++)
                 {
-                    velocity.y -= (_component._playerData.Gravity *
-                                   (velocity.y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
-                    velocity.y = Mathf.Max(velocity.y, -_component._playerData.GravityLimit);
+                    var y = velocity.y;
+
+                    y -= (_component._playerData.Gravity *
+                                   (y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
+                    y = Mathf.Max(y, -_component._playerData.GravityLimit);
+
+                    velocity.y = 0;
+                    velocity = Vector3.MoveTowards(velocity, Vector3.zero, _component._playerData.AirControl * _delta);
+
+                    velocity.y = y;
 
                     Handles.DrawDottedLine(pos, pos + velocity * _delta, 3);
                     pos += velocity * _delta;

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -18,7 +18,7 @@ namespace SuraSang
         private PuzzleTrampolin _component;
 
 
-        void OnSceneGUI()
+        private void OnSceneGUI()
         {
             EditorGUI.BeginChangeCheck();
 

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs.meta
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a09292b9c110742acbd4ded4a7d384c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleDirectionBase.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleDirectionBase.cs
@@ -6,10 +6,12 @@ namespace SuraSang
 {
     public class PuzzleContextDirection : PuzzleContext
     {
-        public Vector3 Dir;
+        public CharacterMove Character { get; private set; }
+        public Vector3 Dir { get; private set; }
 
-        public PuzzleContextDirection(Vector3 dir)
+        public PuzzleContextDirection(CharacterMove character, Vector3 dir)
         {
+            Character = character;
             Dir = dir;
         }
     }

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleDirectionBase.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleDirectionBase.cs
@@ -19,8 +19,10 @@ namespace SuraSang
 
     public abstract class PuzzleDirectionBase : PuzzleElements
     {
-        [SerializeField] private float StartAngle = 0;
         protected const int DirCount = 6;
+        
+        public float StartAngle => _startAngle;
+        [SerializeField] private float _startAngle = 0;
 
         protected PuzzleContextDirection _context;
 

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleDirectionBase.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleDirectionBase.cs
@@ -17,7 +17,8 @@ namespace SuraSang
 
     public abstract class PuzzleDirectionBase : PuzzleElements
     {
-        [SerializeField] private float StartAngle = 0;
+        public float StartAngle => _startAngle;
+        [SerializeField] private float _startAngle = 0;
         protected const int DirCount = 6;
 
         protected PuzzleContextDirection _context;
@@ -56,14 +57,14 @@ namespace SuraSang
 
             for (int i = 0; i < DirCount; i++)
             {
-                var result = StartAngle + i * plusAngle;
+                var result = _startAngle + i * plusAngle;
                 if (Mathf.Abs(result - angle) < plusAngle * 0.5f)
                 {
                     return result;
                 }
             }
 
-            return StartAngle;
+            return _startAngle;
         }
 
         protected void OnDrawGizmos()
@@ -74,7 +75,7 @@ namespace SuraSang
 
             for (int i = 0; i < DirCount; i++)
             {
-                var dir = GetVector((StartAngle + i * plusAngle) * Mathf.Deg2Rad).normalized * 3;
+                var dir = GetVector((_startAngle + i * plusAngle) * Mathf.Deg2Rad).normalized * 3;
                 Gizmos.DrawLine(transform.position, transform.position + dir);
             }
         }

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
@@ -14,9 +14,19 @@ namespace SuraSang
 
         public Transform JumpPoint => _jumpPoint;
         [SerializeField] private Transform _jumpPoint;
-        
+
+        public float MinHeight;
+
         public float JumpVelocity; // 횡으로 이동하는 속도
         public float PowerReduction; // Y속도 줄이기
+
+        private float _minVelocity;
+
+        private void Awake()
+        {
+            var gravity = _playerData.Gravity * _playerData.FallingGravityMultiplier;
+            _minVelocity = Mathf.Sqrt(gravity * 2 * MinHeight) * PowerReduction;
+        }
 
         public override void OnNotify(PuzzleContext context)
         {
@@ -27,10 +37,21 @@ namespace SuraSang
                 return;
             }
 
+            if (!(_context.Character is Player))
+            {
+                return; // 몬스터도 트램펄린 띄우고 싶다...
+            }
+
             var angle = GetNearestAngle(GetAngle(_context.Dir)) + 180;
-            var vector = GetVector(angle * Mathf.Deg2Rad);
-            
-            
+            var jumpDir = GetVector(angle * Mathf.Deg2Rad) * JumpVelocity;
+
+
+            jumpDir.y = Mathf.Max(_minVelocity, -_context.Dir.y) * PowerReduction;
+
+            var character = _context.Character;
+
+            character.MovePosition(JumpPoint.position);
+            character.ChangeState(new PlayerMoveJumping(character, jumpDir));
         }
 
         private void OnDrawGizmos() { }// override용

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
@@ -26,10 +26,10 @@ namespace SuraSang
         private float _minVelocity;
         private float _lastJumpTime;
 
-        private void Awake()
+        private void Update()
         {
             var gravity = _playerData.Gravity * _playerData.FallingGravityMultiplier;
-            _minVelocity = Mathf.Sqrt(gravity * 2 * MinHeight) * PowerReduction;
+            _minVelocity = Mathf.Sqrt(gravity * 2 * MinHeight);
         }
 
         public override void OnNotify(PuzzleContext context)
@@ -59,11 +59,12 @@ namespace SuraSang
 
             jumpDir.y = Mathf.Max(_minVelocity, -_context.Dir.y) * PowerReduction;
 
-            Debug.LogError(jumpDir);
-
             var character = _context.Character;
             character.ChangeState(new PlayerMoveJumping(character, jumpDir));
-            character.MovePosition(JumpPoint.position);
+
+            var pos = character.transform.position;
+            pos.y = JumpPoint.position.y;
+            character.MovePosition(pos);
         }
 
         private void OnDrawGizmos() { }// override용

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace SuraSang
+{
+    public class PuzzleTrampolin : PuzzleDirectionBase
+    {
+        [Header("높이 체크 (디버그용)")]
+        public float[] DebugHeight; // 특정 높이에서 떨어졌을 때 얼마나 튀어오르는지 씬 GUI로 보여주기 위해
+        public PlayerData _playerData;
+
+        public Transform JumpPoint => _jumpPoint;
+        [SerializeField] private Transform _jumpPoint;
+        
+        public float JumpVelocity; // 횡으로 이동하는 속도
+        public float PowerReduction; // Y속도 줄이기
+
+        public override void OnNotify(PuzzleContext context)
+        {
+            base.OnNotify(context);
+
+            if (_context == null)
+            {
+                return;
+            }
+
+            var angle = GetNearestAngle(GetAngle(_context.Dir)) + 180;
+            var vector = GetVector(angle * Mathf.Deg2Rad);
+            
+            
+        }
+
+        private void OnDrawGizmos() { }// override용
+    }
+}

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs.meta
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5193480c5b64b44d9ac084a77cc23d1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Skill/AngerSkill.cs
+++ b/Assets/Scripts/Skill/AngerSkill.cs
@@ -81,7 +81,7 @@ namespace SuraSang
             foreach (var hit in result)
             {
                 Debug.Log(hit.transform.gameObject.name);
-                hit.GetComponent<Collider>()?.GetComponentInParent<PuzzleElements>()?.OnNotify(new PuzzleContextDirection(_player.transform.forward));
+                hit.GetComponent<Collider>()?.GetComponentInParent<PuzzleElements>()?.OnNotify(new PuzzleContextDirection(_player, _player.transform.forward));
             }
 
             if (result.Length != 0 || (Time.time - _dashStartTime) > SkillRunningTime)

--- a/Assets/_Resources/Prefabs/Trampolin.prefab
+++ b/Assets/_Resources/Prefabs/Trampolin.prefab
@@ -113,11 +113,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _startAngle: 0
   DebugHeight:
-  - 1.0847058
-  - 3.946379
+  - 2.2251067
+  - 3.3045485
+  - 4.3398333
   _playerData: {fileID: 11400000, guid: 257db9c9563e942c2ae42559a612653a, type: 2}
   _jumpPoint: {fileID: 8514280265155238081}
-  JumpVelocity: 3.4225805
+  Cooltime: 0.1
+  MinHeight: 1.3636377
+  JumpVelocity: 7
   PowerReduction: 0.7
 --- !u!1 &8514280265155238080
 GameObject:

--- a/Assets/_Resources/Prefabs/Trampolin.prefab
+++ b/Assets/_Resources/Prefabs/Trampolin.prefab
@@ -1,0 +1,152 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8514280264026734208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8514280264026734213}
+  - component: {fileID: 8514280264026734212}
+  - component: {fileID: 8514280264026734215}
+  - component: {fileID: 8514280264026734214}
+  - component: {fileID: 8514280264026734209}
+  m_Layer: 0
+  m_Name: Trampolin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8514280264026734213
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8514280264026734208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.72, y: -0.21, z: -21.48}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8514280265155238081}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8514280264026734212
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8514280264026734208}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8514280264026734215
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8514280264026734208}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &8514280264026734214
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8514280264026734208}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8514280264026734209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8514280264026734208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5193480c5b64b44d9ac084a77cc23d1e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _startAngle: 0
+  DebugHeight:
+  - 1.0847058
+  - 3.946379
+  _playerData: {fileID: 11400000, guid: 257db9c9563e942c2ae42559a612653a, type: 2}
+  _jumpPoint: {fileID: 8514280265155238081}
+  JumpVelocity: 3.4225805
+  PowerReduction: 0.7
+--- !u!1 &8514280265155238080
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8514280265155238081}
+  m_Layer: 0
+  m_Name: JumpPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8514280265155238081
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8514280265155238080}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8514280264026734213}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/_Resources/Prefabs/Trampolin.prefab.meta
+++ b/Assets/_Resources/Prefabs/Trampolin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3fa5e5b62c73458fb87b63a0adbd8c0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**트램폴린과 트램폴린 에디터 추가**

트램펄린 스펙 : 
플레이어가 트램폴린에 떨어졌을때
특정 각도로 날아감 (날아가는 각도를 구하는 방식은 통나무와 동일)

이때 날아가는 거리는 고정되어 있으며
점프하는 높이는 플레이어가 떨어지는 높이에 비례함


- 방향퍼즐을 상속해 만들어짐
- 일단 OnNotify를 트램폴린이 OnTriggerEnter를 통해 직접 호출하도록 만들었는데
나쁘지 않은데 뭔가 뭔가 조금더 잘 구조를 만들 수 있을 것 같다는 생각이 듬...

**점프 상태 생성자 기능 추가**

트램폴린을 위해 MoveDir 덮어쓰는 기능 추가


**CharacterMove 강제 이동 기능 추가**

CharacterMove 에 강제 이동을 위한 추상함수 추가


**에디터 기능**

![image](https://user-images.githubusercontent.com/96484044/196459406-75e82711-3b1f-4963-b039-c44f0d2dc159.png)



#핸들 종류
**1 : 날아가는 거리 조절하는 핸들**
**2 : 최소 높이**
**3 : 디버그용 높이**

2번과 3번 높이에 따라 예측할 수 있는 포물선이 그려짐
- 포물선은 점프하면서 아무런 조작을 하지 않았을 때를 기준으로 하기 때문에
실제 게임에서는 다르게 이동할 수 있음