### PR TITLE
빌드 에러 수정

### DIFF
--- a/Assets/Scripts/Core/ReadOnlyAttribute.cs
+++ b/Assets/Scripts/Core/ReadOnlyAttribute.cs
@@ -7,7 +7,8 @@ namespace SuraSang
     {
  
     }
- 
+
+#if UNITY_EDITOR
     [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
     public class ReadOnlyDrawer : PropertyDrawer
     {
@@ -26,4 +27,5 @@ namespace SuraSang
             GUI.enabled = true;
         }
     }
+#endif
 }

--- a/Assets/Scripts/EventSystem/Events/DoorTrigger.cs
+++ b/Assets/Scripts/EventSystem/Events/DoorTrigger.cs
@@ -1,10 +1,4 @@
-using Cinemachine;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEditor.UIElements;
 using UnityEngine;
-using UnityEngine.Lumin;
-using UnityEngine.UI;
 
 namespace SuraSang
 {

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -193,6 +193,7 @@ namespace SuraSang
             _cart.m_Position = 0f;
         }
 
+#if UNITY_EDITOR
         private void OnDrawGizmos()
         {
             if (_debugMode)
@@ -221,6 +222,7 @@ namespace SuraSang
                 Gizmos.DrawWireSphere(transform.position, HappySkill.CheckRange);
             }
         }
+#endif
 
         private void OnReset(bool isOn)
         {


### PR DESCRIPTION
DoorTrigger 에서 사용하던 using 정리 (using UnityEditor.UIElements; )

Player OnDrawGizmo 함수 빌드 제외

ReadOnly ReadOnlyDrawer 클래스 빌드 제외