### PR TITLE
SO데이터 매니저 추가 및 감정별 이동 속도 변화

### DIFF
--- a/Assets/Resources/SO/Player Data.asset
+++ b/Assets/Resources/SO/Player Data.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
   _runMultiplier: 1.5
   _grabMultiplier: 0.5
   _gravity: 50
-  _fallingGravityMultiplier: 1.5
+  _fallingGravityMultiplier: 1
   _gravityLimit: 200
   _jumpPower: 10
   _coyoteTime: 0.3

--- a/Assets/Resources/SO/Player Data.asset
+++ b/Assets/Resources/SO/Player Data.asset
@@ -36,3 +36,10 @@ MonoBehaviour:
   _moveToLedgeSpeed: 1
   _absorbAngle: 160
   _absorbRange: 2.75
+  _emotionDatas:
+  - _emotion: 1
+    _speedMultiplier: 1.5
+  - _emotion: 2
+    _speedMultiplier: 1
+  - _emotion: 3
+    _speedMultiplier: 0.5

--- a/Assets/Scripts/Core/GameData/SODataManager.cs
+++ b/Assets/Scripts/Core/GameData/SODataManager.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using System;
+using UnityEngine;
+
+namespace SuraSang
+{
+    //public abstract class SOData : ScriptableObject
+    //{
+    //    public string DataName
+    //}
+
+    public class SODataManager
+    {
+        private const string SODataPath = "SO/";
+
+        private Dictionary<Type, ScriptableObject> _datas = new Dictionary<Type, ScriptableObject>();
+
+        public SODataManager()
+        {
+            LoadDatas();
+        }
+
+        public void LoadDatas()
+        {
+            _datas.Clear();
+
+            var datas = Resources.LoadAll<ScriptableObject>(SODataPath);
+            foreach (var data in datas)
+            {
+                _datas.TryAdd(data.GetType(), data);
+            }
+        }
+
+        public T GetData<T>() where T : ScriptableObject
+        {
+            if(!_datas.TryGetValue(typeof(T), out var data))
+            {
+                Debug.LogError($"{typeof(T)} 데이터를 찾을 수 없습니다");
+                return null;
+            }
+            return data as T;
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameData/SODataManager.cs.meta
+++ b/Assets/Scripts/Core/GameData/SODataManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f6249bd812df6740bc5bcfe9ca51694
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Global.cs
+++ b/Assets/Scripts/Core/Global.cs
@@ -6,9 +6,10 @@ namespace SuraSang
 {
     public class Global
     {
-        private Global() 
+        private Global()
         {
             _resourceManager = new ResourceManager();
+            _soDataManager = new SODataManager();
         }
 
         private static Global _instance = null;
@@ -33,9 +34,11 @@ namespace SuraSang
         public SceneMaster SceneMaster => _sceneMaster;
         private SceneMaster _sceneMaster;
 
-
         public ResourceManager ResourceManager => _resourceManager;
         private ResourceManager _resourceManager;
+
+        public SODataManager SODataManager => _soDataManager;
+        private SODataManager _soDataManager;
 
     }
 }

--- a/Assets/Scripts/GameData/SO/PlayerData.cs
+++ b/Assets/Scripts/GameData/SO/PlayerData.cs
@@ -4,21 +4,35 @@ using UnityEngine;
 
 namespace SuraSang
 {
+    [System.Serializable]
+    public class EmotionData
+    {
+        [ReadOnly][SerializeField] private Emotion _emotion;
+
+        public float SpeedMultiplier => _speedMultiplier;
+        [SerializeField] private float _speedMultiplier = 1;
+
+        public EmotionData(Emotion emotion)
+        {
+            _emotion = emotion;
+        }
+    }
+
     [CreateAssetMenu(fileName = "Player Data", menuName = "SOData/PlayerData")]
     public class PlayerData : ScriptableObject
     {
         [Header("레이어 마스크")]
         [SerializeField] private LayerMask _headCheckLayer;
         public LayerMask HeadCheckLayer => _headCheckLayer; // 머리 체크
-        
+
         [SerializeField] private LayerMask _edgeCheckLayer;
         public LayerMask EdgeCheckLayer => _edgeCheckLayer; // 잡기 체크
-        
+
         [SerializeField] private LayerMask _enemyCheckLayer;
         public LayerMask EnemyCheckLayer => _enemyCheckLayer; // 적 체크
 
-        
-        [Header("이동")] 
+
+        [Header("이동")]
         [SerializeField] private float _speed;
         public float Speed => _speed;
 
@@ -27,9 +41,9 @@ namespace SuraSang
 
         [SerializeField] private float _grabMultiplier;
         public float GrabMultiplier => _grabMultiplier; // 절벽 잡고 움직일 때 속도에 곱해지는 값
-    
-        
-        [Header("중력")] 
+
+
+        [Header("중력")]
         [SerializeField] private float _gravity;
         public float Gravity => _gravity;
 
@@ -38,22 +52,22 @@ namespace SuraSang
 
         [SerializeField] private float _gravityLimit;
         public float GravityLimit => _gravityLimit; // 최대로 떨어지는 속도
-        
-        
+
+
         [Header("점프")]
         [SerializeField] private float _jumpPower;
         public float JumpPower => _jumpPower;
-        
+
         [SerializeField] private float _coyoteTime;
         public float CoyoteTime => _coyoteTime; // 절벽 끝나고 플레이어가 공중에 있어도 일정 시간동안 점프 가능
-        
+
         [SerializeField] private float _variableJumpTime;
         public float VariableJumpTime => _variableJumpTime; // 꾸욱 누르면 더 올라가는 기능
-        
+
         [SerializeField] private float _airControl;
         public float AirControl => _airControl; // 공중에서 컨트롤가능한 정도
-        
-        
+
+
         [Header("메달리기")]
         [SerializeField] private float _climbPower;
         public float ClimbPower => _climbPower;
@@ -63,16 +77,28 @@ namespace SuraSang
 
         [SerializeField] private float _moveToLedgeSpeed;
         public float MoveToLedgeSpeed => _moveToLedgeSpeed; // 매달리기 거리 보다 멀어 질려고 할때 다시 붙는 속도
-        
-        
+
+
         [Header("흡수")]
         [Range(0f, 360f)]
         [SerializeField] private float _absorbAngle;
         public float AbsorbAngle => _absorbAngle;
-        
+
         [SerializeField] private float _absorbRange;
         public float AbsorbRange => _absorbRange;
-        
-        
+
+
+        [Header("감정 데이터")]
+        [SerializeField] private EmotionData[] _emotionDatas = new EmotionData[3];
+        public EmotionData[] EmotionDatas => _emotionDatas;
+
+
+        private void Awake()
+        {
+            _emotionDatas = new EmotionData[3];
+            _emotionDatas[0] = new EmotionData((Emotion)1);
+            _emotionDatas[1] = new EmotionData((Emotion)2);
+            _emotionDatas[2] = new EmotionData((Emotion)3);
+        }
     }
 }

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -150,5 +150,17 @@ namespace SuraSang
         {
             return (Physics.Raycast(transform.position, transform.forward, out var edgeHit, PlayerData.EdgeDetectLength, PlayerData.EdgeCheckLayer), edgeHit);
         }
+
+        public float GetPlayerSpeed()
+        {
+            var speed = PlayerData.Speed;
+
+            if (CurrentEmotion != Emotion.Default)
+            {
+                speed *= PlayerData.EmotionDatas[(int)CurrentEmotion - 1].SpeedMultiplier;
+            }
+
+            return speed;
+        }
     }
 }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -15,8 +15,7 @@ namespace SuraSang
 
         public CharacterController Controller { get; private set; }
         public Animator Animator { get; private set; }
-        public PlayerData PlayerData => _playerData;
-        [SerializeField] private PlayerData _playerData;
+        public PlayerData PlayerData { get; private set; }
 
         // 슬픔 스킬용
         public SadEye[] SadEyes => _sadEyes;
@@ -36,6 +35,8 @@ namespace SuraSang
 
         private void Awake()
         {
+            PlayerData = Global.Instance.SODataManager.GetData<PlayerData>();
+
             Controller = GetComponent<CharacterController>();
             Animator = GetComponentInChildren<Animator>();
             _currentCharacter = _characterDefault;

--- a/Assets/Scripts/Player/PlayerState/PlayerMoveGrounded.cs
+++ b/Assets/Scripts/Player/PlayerState/PlayerMoveGrounded.cs
@@ -12,8 +12,8 @@ namespace SuraSang
         public PlayerMoveGrounded(CharacterMove characterMove) : base(characterMove) { }
 
         private float _lastGroundTime;
-        private float _speed;
         private bool _isDancing = false;
+        private bool _isRunning = false;
 
         public override void InitializeState()
         {
@@ -24,8 +24,6 @@ namespace SuraSang
             _player.SetAction(ButtonActions.Jump, OnJump);
             _player.SetAction(ButtonActions.Skill, OnSkill);
             _player.SetAction(ButtonActions.Dance, OnDance);
-
-            _speed = _player.PlayerData.Speed;
         }
 
         public override void UpdateState()
@@ -67,7 +65,7 @@ namespace SuraSang
 
         private void OnRun(bool isOn)
         {
-            _speed = isOn ? _player.PlayerData.Speed * _player.PlayerData.RunMultiplier : _player.PlayerData.Speed;
+            _isRunning = isOn;
             if (isOn) _player.Animator.SetBool("IsRunning", true);
             else _player.Animator.SetBool("IsRunning", false);
         }
@@ -89,7 +87,14 @@ namespace SuraSang
                 _player.SmoothRotation(dir);
             }
 
-            dir *= _speed;
+            var speed = _player.GetPlayerSpeed();
+
+            if (_isRunning)
+            {
+                speed *= _player.PlayerData.RunMultiplier;
+            }
+
+            dir *= speed;
             dir.y = _controller.isGrounded ? -1 : _player.MoveDir.y - _player.PlayerData.Gravity * Time.deltaTime;
             _player.MoveDir = dir;
 

--- a/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/Editor/PuzzleTrampolinEditor.cs
@@ -17,9 +17,16 @@ namespace SuraSang
 
         private PuzzleTrampolin _component;
 
+        private PlayerData _playerData;
+
+        private void Awake()
+        {
+            _playerData = Global.Instance.SODataManager.GetData<PlayerData>();
+        }
 
         private void OnSceneGUI()
         {
+
             EditorGUI.BeginChangeCheck();
 
             _component = target as PuzzleTrampolin;
@@ -44,7 +51,7 @@ namespace SuraSang
             DrawArcs(_component.MinHeight);
 
             // 높이 (그냥 표시용)
-            var gravity = _component._playerData.Gravity * _component._playerData.FallingGravityMultiplier;
+            var gravity = _playerData.Gravity * _playerData.FallingGravityMultiplier;
 
             for (int i = 0; i < _component.DebugHeight.Length; i++)
             {
@@ -74,7 +81,7 @@ namespace SuraSang
 
         private void DrawArcs(float height)
         {
-            var gravity = _component._playerData.Gravity * _component._playerData.FallingGravityMultiplier;
+            var gravity = _playerData.Gravity * _playerData.FallingGravityMultiplier;
             float vel = Mathf.Sqrt(gravity * 2 * height) * _component.PowerReduction;
 
             var plusAngle = 360f / _dirCount;
@@ -91,12 +98,12 @@ namespace SuraSang
                 {
                     var y = velocity.y;
 
-                    y -= (_component._playerData.Gravity *
-                                   (y < 0 ? _component._playerData.FallingGravityMultiplier : 1)) * _delta;
-                    y = Mathf.Max(y, -_component._playerData.GravityLimit);
+                    y -= (_playerData.Gravity *
+                                   (y < 0 ? _playerData.FallingGravityMultiplier : 1)) * _delta;
+                    y = Mathf.Max(y, -_playerData.GravityLimit);
 
                     velocity.y = 0;
-                    velocity = Vector3.MoveTowards(velocity, Vector3.zero, _component._playerData.AirControl * _delta);
+                    velocity = Vector3.MoveTowards(velocity, Vector3.zero, _playerData.AirControl * _delta);
 
                     velocity.y = y;
 

--- a/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
+++ b/Assets/Scripts/PuzzleSystem/Direction/PuzzleTrampolin.cs
@@ -10,14 +10,11 @@ namespace SuraSang
     {
         [Header("높이 체크 (디버그용)")]
         public float[] DebugHeight; // 특정 높이에서 떨어졌을 때 얼마나 튀어오르는지 씬 GUI로 보여주기 위해
-        public PlayerData _playerData;
 
         public Transform JumpPoint => _jumpPoint;
         [SerializeField] private Transform _jumpPoint;
 
-
         public float Cooltime;
-
         public float MinHeight;
 
         public float JumpVelocity; // 횡으로 이동하는 속도
@@ -26,15 +23,15 @@ namespace SuraSang
         private float _minVelocity;
         private float _lastJumpTime;
 
-        private void Update()
+        private void Awake()
         {
-            var gravity = _playerData.Gravity * _playerData.FallingGravityMultiplier;
+            var data = Global.Instance.SODataManager.GetData<PlayerData>();
+            var gravity = data.Gravity * data.FallingGravityMultiplier;
             _minVelocity = Mathf.Sqrt(gravity * 2 * MinHeight);
         }
 
         public override void OnNotify(PuzzleContext context)
         {
-
             base.OnNotify(context);
 
             if (_context == null)
@@ -51,6 +48,13 @@ namespace SuraSang
             {
                 return;
             }
+
+#if UNITY_EDITOR
+            // 에디터에서 MinHeight를 계속 수정하는 경우를 반영
+            var data = Global.Instance.SODataManager.GetData<PlayerData>();
+            var gravity = data.Gravity * data.FallingGravityMultiplier;
+            _minVelocity = Mathf.Sqrt(gravity * 2 * MinHeight);
+#endif
 
             _lastJumpTime = Time.time;
 


### PR DESCRIPTION
**SODataManager 추가**

생성될 때 Resources.LoadAll로 스크립터들 오브젝트들을 불러와
 Type을 키로 가지고 있는 딕셔너리에 저장시키고

**SODataManager.GetData<PlayerData>()** 같은 모양으로 데이터를 불러올 수 있도록 하였습니다.


**PlayerData 직접 링크 하던 부분을 데이터 매니저를 통해 가져오도록 수정**

SODataManager는 다른 매니저 클래스 같이 Global 에서 가져올 수 있도록 만들었습니다.

따라서 최종적으로
`Global.Instance.SODataManager.GetData<PlayerData>()`
같은 모양으로 데이터를 불러오게 됩니다

트램펄린 에디터 같이 플레이어에 종속된 것은 아니지만 플레이어 데이터(중력값)가 필요할 경우 유용하게 사용될 수 있습니다.

**감정별 이동 속도 변화**

솔직히 이건 어떻게 깔끔하게 만들 수 있을지 잘 모르겠습니다...

일단 감정 별 데이터를 배열에 담아 불러오는 방식으로 처리했습니다.