### PR TITLE
애니메이션 속도 적용

### DIFF
--- a/Assets/Resources/SO/Player Data.asset
+++ b/Assets/Resources/SO/Player Data.asset
@@ -37,6 +37,8 @@ MonoBehaviour:
   _absorbAngle: 160
   _absorbRange: 2.75
   _emotionDatas:
+  - _emotion: 0
+    _speedMultiplier: 1
   - _emotion: 1
     _speedMultiplier: 1.5
   - _emotion: 2

--- a/Assets/Scripts/GameData/SO/PlayerData.cs
+++ b/Assets/Scripts/GameData/SO/PlayerData.cs
@@ -7,7 +7,7 @@ namespace SuraSang
     [System.Serializable]
     public class EmotionData
     {
-        [ReadOnly][SerializeField] private Emotion _emotion;
+        [SerializeField] private Emotion _emotion;
 
         public float SpeedMultiplier => _speedMultiplier;
         [SerializeField] private float _speedMultiplier = 1;
@@ -93,12 +93,12 @@ namespace SuraSang
         public EmotionData[] EmotionDatas => _emotionDatas;
 
 
-        private void Awake()
-        {
-            _emotionDatas = new EmotionData[3];
-            _emotionDatas[0] = new EmotionData((Emotion)1);
-            _emotionDatas[1] = new EmotionData((Emotion)2);
-            _emotionDatas[2] = new EmotionData((Emotion)3);
-        }
+        //private void Awake()
+        //{
+        //    _emotionDatas = new EmotionData[3];
+        //    _emotionDatas[0] = new EmotionData((Emotion)1);
+        //    _emotionDatas[1] = new EmotionData((Emotion)2);
+        //    _emotionDatas[2] = new EmotionData((Emotion)3);
+        //}
     }
 }

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -23,8 +23,6 @@ namespace SuraSang
 
     public partial class Player
     {
-        private readonly int MoveSpeedParam = Animator.StringToHash("MoveSpeed");
-
         // 벡터를 넘겨주기 위해 move만 따로 처리
         public UnityAction<Vector2> OnMove { get; set; }
         private Dictionary<ButtonActions, InputAction> _buttonActions;
@@ -94,8 +92,6 @@ namespace SuraSang
             var moveInput = _moveInputAction.ReadValue<Vector2>();
 
             OnMove?.Invoke(moveInput);
-
-            Animator.SetFloat(MoveSpeedParam, moveInput.magnitude);
         }
 
         private void OnEnable()

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -23,6 +23,8 @@ namespace SuraSang
 
     public partial class Player
     {
+        private readonly int MoveSpeedParam = Animator.StringToHash("MoveSpeed");
+
         // 벡터를 넘겨주기 위해 move만 따로 처리
         public UnityAction<Vector2> OnMove { get; set; }
         private Dictionary<ButtonActions, InputAction> _buttonActions;
@@ -92,6 +94,8 @@ namespace SuraSang
             var moveInput = _moveInputAction.ReadValue<Vector2>();
 
             OnMove?.Invoke(moveInput);
+
+            Animator.SetFloat(MoveSpeedParam, moveInput.magnitude);
         }
 
         private void OnEnable()

--- a/Assets/Scripts/Player/Player.Input.cs
+++ b/Assets/Scripts/Player/Player.Input.cs
@@ -155,10 +155,7 @@ namespace SuraSang
         {
             var speed = PlayerData.Speed;
 
-            if (CurrentEmotion != Emotion.Default)
-            {
-                speed *= PlayerData.EmotionDatas[(int)CurrentEmotion - 1].SpeedMultiplier;
-            }
+            speed *= PlayerData.EmotionDatas[(int)CurrentEmotion].SpeedMultiplier;
 
             return speed;
         }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -11,7 +11,11 @@ namespace SuraSang
 {
     public partial class Player : CharacterMove
     {
+        private readonly int MoveSpeedParam = Animator.StringToHash("MoveSpeed");
+
+
         [SerializeField] private bool _debugMode = false;
+
 
         public CharacterController Controller { get; private set; }
         public Animator Animator { get; private set; }
@@ -77,6 +81,8 @@ namespace SuraSang
             if (CanMove)
             {
                 Controller.Move(MoveDir * Time.deltaTime);
+
+                Animator.SetFloat(MoveSpeedParam, new Vector2(Controller.velocity.x, Controller.velocity.z).magnitude);
             }
 
             if (IsReset)

--- a/Assets/_Resources/Characters/Player/Animations/AC_Player.controller
+++ b/Assets/_Resources/Characters/Player/Animations/AC_Player.controller
@@ -1862,13 +1862,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 7038085d452b7084285918eefb50ec2d, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -2192,67 +2192,73 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsRunning
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: MoveSpeed
+    m_Type: 1
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: IsJumping
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsFalling
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsHolding
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsUseSkill
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Forward
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Left
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Change
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Dance
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Collide
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -2347,13 +2353,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 15a9de001659a674fbf8963af60e334b, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 

--- a/Assets/_Resources/Characters/Player/Animations/AC_Player.controller
+++ b/Assets/_Resources/Characters/Player/Animations/AC_Player.controller
@@ -337,7 +337,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Walk
-  m_Speed: 1
+  m_Speed: 0.14285715
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -1995073933078822080}
@@ -350,13 +350,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: cc581c483c022b741a5f78352f316ba1, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -1320,7 +1320,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Run
-  m_Speed: 1
+  m_Speed: 0.21428572
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -2021182979707270110}
@@ -1332,13 +1332,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: fffa5e323d1ae344dae78214c45386e1, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -1850,7 +1850,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Run
-  m_Speed: 1
+  m_Speed: 0.14285715
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 7000982206699578361}
@@ -2340,7 +2340,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Walk
-  m_Speed: 1
+  m_Speed: 0.14285715
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -6615030906606499514}
@@ -2695,7 +2695,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Run
-  m_Speed: 1
+  m_Speed: 0.14285715
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 4409012907414159913}
@@ -2707,13 +2707,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 0c4fa7cffaee70c43997efff8b4015f5, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -3882,7 +3882,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Walk
-  m_Speed: 1
+  m_Speed: 0.2857143
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 747480864818654541}
@@ -3894,13 +3894,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 5533b937f4d38744ab850c8d34cf75eb, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
@@ -4396,7 +4396,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Walk
-  m_Speed: 1
+  m_Speed: 0.21428572
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8699010939753555594}
@@ -4409,13 +4409,13 @@ AnimatorState:
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
   m_Mirror: 0
-  m_SpeedParameterActive: 0
+  m_SpeedParameterActive: 1
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 205e0ea7e2a7e5f4fbce8e7ae5c64b33, type: 2}
   m_Tag: 
-  m_SpeedParameter: 
+  m_SpeedParameter: MoveSpeed
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 


### PR DESCRIPTION
**애니메이터 파라미터에 "MoveSpeed"추가**

플레이어 애니메이터 파라미터에 MoveSpeed 라는 float형을 추가하여
각 레이어마다 Run과 Walk 속도에 적용했습니다.

플레이어 스크립트의 Update에서 MoveSpeed에 캐릭터 컨트롤러 velocity의 크기(x,z축만)를 넘겨줘서 
걷기와 달리기의 애니메이션 속도를 조절합니다.

일단 애니메이터에서 걷기와 달리기 애니메이션들의 속도를 수정했습니다. 
(플레이어 속도 1 이라는 상황을 가정해 설정)

**플레이어 데이터 버그 수정**

플레이어 데이터 Awake에서 감정 별 데이터를 초기화하는 부분이 있는데
그 것 때문에 풀 받을 때마다 감정 별 데이터가 초기화 되었음

초기화부분 주석처리하고 감정 별 데이터 클래스의 감정 선택 부분에 ReadOnly 어트리뷰트 제거