### PR TITLE
CameraSwitcher 필요없는 구문 삭제

### DIFF
--- a/Assets/Scripts/Camera/CameraTriggerVolume.cs
+++ b/Assets/Scripts/Camera/CameraTriggerVolume.cs
@@ -10,27 +10,13 @@ namespace SuraSang
     public class CameraTriggerVolume : MonoBehaviour
     {
         [SerializeField] private CinemachineVirtualCamera _camera;
-        [SerializeField] private Vector3 _boxSize;
-
         private BoxCollider _box;
-        private Rigidbody _rb;
 
 
         private void Awake()
         {
             _box = GetComponent<BoxCollider>();
-            _rb = GetComponent<Rigidbody>();
-
             _box.isTrigger = true;
-            // _box.size = _boxSize;
-
-            _rb.isKinematic = true;
-        }
-
-        private void OnDrawGizmos()
-        {
-            Gizmos.color = Color.green;
-            Gizmos.DrawWireCube(transform.position, _boxSize);
         }
 
         private void OnTriggerEnter(Collider other)


### PR DESCRIPTION
간단한 풀리퀘입니다.
콜리전이 아닌 트리거로 시스템을 바꾸면서 Rigidbody를 사용 할 필요가 없어서
관련 구문들 제거했습니다.