### PR TITLE
플레이어 연출 카메라 변경

### DIFF
--- a/Assets/Scripts/Player/Player.Absorb.cs
+++ b/Assets/Scripts/Player/Player.Absorb.cs
@@ -91,6 +91,7 @@ namespace SuraSang
                                 Global.Instance.ResourceManager.ReturnParticleSystem(Constant.SadAbsorbEffectPath, obj);
                                 break;
                         }
+                        transform.rotation = Quaternion.Euler(0, 0, 0);
                         Animator.SetTrigger("Change");
                         _hitTargetContainer[i].gameObject.GetComponent<Monster>().Absorbed();
                         _hitTargetContainer[i].gameObject.GetComponent<Animator>().SetTrigger("Absorbed");

--- a/Assets/Scripts/Player/Player.Absorb.cs
+++ b/Assets/Scripts/Player/Player.Absorb.cs
@@ -91,7 +91,6 @@ namespace SuraSang
                                 Global.Instance.ResourceManager.ReturnParticleSystem(Constant.SadAbsorbEffectPath, obj);
                                 break;
                         }
-                        transform.rotation = Quaternion.Euler(0, 0, 0);
                         Animator.SetTrigger("Change");
                         _hitTargetContainer[i].gameObject.GetComponent<Monster>().Absorbed();
                         _hitTargetContainer[i].gameObject.GetComponent<Animator>().SetTrigger("Absorbed");

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -31,6 +31,7 @@ namespace SuraSang
         private CinemachineVirtualCamera _camera;
 
         [SerializeField] private CinemachineDollyCart _cart;
+        [SerializeField] private float _cartSpeed;
 
         [ReadOnly] public bool CanMove = true;
         private GameObject HappyEffect;
@@ -225,7 +226,7 @@ namespace SuraSang
         public void CameraStart()
         {
             _camera.m_Priority = 11;
-            _cart.m_Speed = 0.25f;
+            _cart.m_Speed = _cartSpeed;
         }
 
         public void CameraStop()

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -225,15 +225,17 @@ namespace SuraSang
 
         public void CameraStart()
         {
+            transform.rotation = Quaternion.Euler(0, 0, 0);
+
             _camera.m_Priority = 11;
+
+            _cart.m_Position = 0f;
             _cart.m_Speed = _cartSpeed;
         }
 
         public void CameraStop()
         {
             _camera.m_Priority = 9;
-            _cart.m_Speed = 0f;
-            _cart.m_Position = 0f;
         }
 
 #if UNITY_EDITOR

--- a/Assets/_Resources/Prefabs/Player.prefab
+++ b/Assets/_Resources/Prefabs/Player.prefab
@@ -51,21 +51,9 @@ MonoBehaviour:
     width: 0.2
   m_Looped: 0
   m_Waypoints:
-  - position: {x: 0.21, y: 0.3, z: 2.9}
+  - position: {x: 0, y: -1, z: 5.94}
     roll: 0
-  - position: {x: 0.5, y: 0.01, z: 2.14}
-    roll: 0
-  - position: {x: -0.78, y: 0.18, z: 1.47}
-    roll: 0
-  - position: {x: -4.16, y: 0.99, z: 1.58}
-    roll: 0
-  - position: {x: -6.12, y: 1.31, z: -1.16}
-    roll: 0
-  - position: {x: 0.84, y: -0.88, z: -5.73}
-    roll: 0
-  - position: {x: 4.68, y: -0.6, z: 0.79}
-    roll: 0
-  - position: {x: 0, y: -0.19271922, z: 2.5200005}
+  - position: {x: 0, y: -1, z: 1.9}
     roll: 0
 --- !u!1 &773242893
 GameObject:
@@ -186,8 +174,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1217311112}
-  m_LocalRotation: {x: 0.06582495, y: 0.92283165, z: -0.18255576, w: 0.33274955}
-  m_LocalPosition: {x: 0.20999908, y: 0.8799999, z: 2.8999996}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: -0.42000008, z: 5.9400005}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -235,8 +223,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2024799159}
-  m_LocalRotation: {x: -0.005290911, y: 0.9885768, z: -0.14632186, w: -0.035746347}
-  m_LocalPosition: {x: 0.20999908, y: 0.8799999, z: 2.8999996}
+  m_LocalRotation: {x: -0.000000001127929, y: 0.99929464, z: 0.03755475, w: 0.000000030013073}
+  m_LocalPosition: {x: 0, y: -0.42000008, z: 5.58}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -282,239 +270,6 @@ MonoBehaviour:
         m_Calls: []
   m_LegacyBlendHint: 0
   m_ComponentOwner: {fileID: 773242894}
---- !u!1 &3350766918145462809
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2046436232426156189}
-  - component: {fileID: 2095774959706704281}
-  m_Layer: 0
-  m_Name: DollyTrack
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2046436232426156189
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3350766918145462809}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.58, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7362189885273058761}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2095774959706704281
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3350766918145462809}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a200b19ca1a9685429ed7e043c28e904, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Resolution: 14
-  m_Appearance:
-    pathColor: {r: 0, g: 0, b: 0, a: 1}
-    inactivePathColor: {r: 0, g: 0, b: 0, a: 1}
-    width: 0.2
-  m_Looped: 0
-  m_Waypoints:
-  - position: {x: 0.21, y: 0.3, z: 2.9}
-    roll: 0
-  - position: {x: 0.5, y: 0.01, z: 2.14}
-    roll: 0
-  - position: {x: -0.78, y: 0.18, z: 1.47}
-    roll: 0
-  - position: {x: -4.16, y: 0.99, z: 1.58}
-    roll: 0
-  - position: {x: -6.12, y: 1.31, z: -1.16}
-    roll: 0
-  - position: {x: 0.84, y: -0.88, z: -5.73}
-    roll: 0
-  - position: {x: 4.68, y: -0.6, z: 0.79}
-    roll: 0
-  - position: {x: 0, y: -0.19271922, z: 2.5200005}
-    roll: 0
---- !u!1 &4177392020095757517
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3610997558721343096}
-  - component: {fileID: 2698853887200455848}
-  - component: {fileID: 8877337700356395562}
-  - component: {fileID: 3716670088745770935}
-  m_Layer: 0
-  m_Name: cm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3610997558721343096
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4177392020095757517}
-  m_LocalRotation: {x: 0.0043198126, y: -0.9847919, z: 0.17190172, w: -0.024823695}
-  m_LocalPosition: {x: -95.623024, y: 3.3683486, z: 18.555021}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5065353645319505468}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2698853887200455848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4177392020095757517}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8877337700356395562
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4177392020095757517}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
-  m_LookaheadTime: 0
-  m_LookaheadSmoothing: 0
-  m_LookaheadIgnoreY: 0
-  m_HorizontalDamping: 0.5
-  m_VerticalDamping: 0.5
-  m_ScreenX: 0.5
-  m_ScreenY: 0.5
-  m_DeadZoneWidth: 0
-  m_DeadZoneHeight: 0
-  m_SoftZoneWidth: 0.8
-  m_SoftZoneHeight: 0.8
-  m_BiasX: 0
-  m_BiasY: 0
-  m_CenterOnActivate: 1
---- !u!114 &3716670088745770935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4177392020095757517}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa7155796051b734daa718462081dc5f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_BindingMode: 1
-  m_FollowOffset: {x: 0, y: 0, z: 0}
-  m_XDamping: 0
-  m_YDamping: 0
-  m_ZDamping: 0
-  m_AngularDampingMode: 0
-  m_PitchDamping: 0
-  m_YawDamping: 0
-  m_RollDamping: 0
-  m_AngularDamping: 0
---- !u!1 &5222263743718531406
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5065353645319505468}
-  - component: {fileID: 1382202400771204664}
-  m_Layer: 0
-  m_Name: TrakcingCamera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5065353645319505468
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5222263743718531406}
-  m_LocalRotation: {x: -0.005290911, y: 0.9885768, z: -0.14632186, w: -0.035746347}
-  m_LocalPosition: {x: 0.20999908, y: 0.8799999, z: 2.8999996}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3610997558721343096}
-  m_Father: {fileID: 7362189885273058761}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1382202400771204664
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5222263743718531406}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ExcludedPropertiesInInspector:
-  - m_Script
-  m_LockStageInInspector: 
-  m_StreamingVersion: 20170927
-  m_Priority: 9
-  m_StandbyUpdate: 2
-  m_LookAt: {fileID: 7362189885273058761}
-  m_Follow: {fileID: 276182005075526960}
-  m_Lens:
-    FieldOfView: 70
-    OrthographicSize: 5
-    NearClipPlane: 0.001
-    FarClipPlane: 500
-    Dutch: 0
-    ModeOverride: 0
-    LensShift: {x: 0, y: 0}
-    GateFit: 2
-    m_SensorSize: {x: 1, y: 1}
-  m_Transitions:
-    m_BlendHint: 0
-    m_InheritPosition: 0
-    m_OnCameraLive:
-      m_PersistentCalls:
-        m_Calls: []
-  m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 3610997558721343096}
 --- !u!1 &7362189885273058762
 GameObject:
   m_ObjectHideFlags: 0
@@ -554,9 +309,6 @@ Transform:
   - {fileID: 69974727}
   - {fileID: 1217311113}
   - {fileID: 2024799160}
-  - {fileID: 2046436232426156189}
-  - {fileID: 276182005075526960}
-  - {fileID: 5065353645319505468}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -646,7 +398,6 @@ MonoBehaviour:
   _characterHappy: {fileID: 7704156342393577629}
   _characterSad: {fileID: 7704156342913165026}
   _debugMode: 0
-  _playerData: {fileID: 11400000, guid: 257db9c9563e942c2ae42559a612653a, type: 2}
   _sadEyes:
   - {fileID: 7362189885339072302}
   - {fileID: 7362189886396816935}
@@ -655,6 +406,7 @@ MonoBehaviour:
   CanMove: 1
   IsSkill: 0
   IsReset: 0
+  IsCheckPointClick: 0
 --- !u!95 &7362189885273058772
 Animator:
   serializedVersion: 4
@@ -1101,55 +853,6 @@ MonoBehaviour:
   _gravity: 0.125
   _downGravity: 0.25
   _sampleCount: 7
---- !u!1 &9044472774956007460
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 276182005075526960}
-  - component: {fileID: 6871303331375406806}
-  m_Layer: 0
-  m_Name: DollyCart
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &276182005075526960
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9044472774956007460}
-  m_LocalRotation: {x: 0.06582495, y: 0.92283165, z: -0.18255576, w: 0.33274955}
-  m_LocalPosition: {x: 0.20999908, y: 0.8799999, z: 2.8999996}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7362189885273058761}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6871303331375406806
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9044472774956007460}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 99a9c787e5d1bbf48a389834c4a9641c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Path: {fileID: 2095774959706704281}
-  m_UpdateMethod: 0
-  m_PositionUnits: 2
-  m_Speed: 0
-  m_Position: 0
 --- !u!1001 &7362189885099714592
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
**연출 카메라 변경**
아마 카메라 관련해서 스크립트 건드리는건 이 PR이 아마도(?)마지막일겁니다.

현재 카메라가 플레이어를 한바퀴 회전하고있는데, 이걸 그냥 정면에서 줌인되는 형식으로 바꿨습니다.
줌인되는 속도(카트스피드) 따로 인스펙터로 빼놨습니다.

+ 플레이어가 흡수할 시 무조건 정면을 바라보게 하게끔 해달라고 해서 플레이어 Rotate를 Zero로 바꾸게 해놨습니다.
사이드뷰 특성상 회전값이 들어갈 시 사이드뷰 고정으로 뒤에 배경이 보이지 않고 빈공간이 보일 수도 있어서 그런 것 같습니다.

[+] 11/14 04:10 흡수할 때 말고 변신에 돌입하기 전에 Rotate를 Zero로 바꾸려고 합니다. 그에 따라서 PR을 Draft로 전환했습니다.
[+] 11/14 13:19 위에 언급한 내용을 최종적으로 적용하여 다시 Marge PR로 돌렸습니다.