### PR TITLE
UI매니저 복제 문제

### DIFF
--- a/Assets/Scripts/Core/Global.cs
+++ b/Assets/Scripts/Core/Global.cs
@@ -14,6 +14,7 @@ namespace SuraSang
             _soDataManager = new SODataManager();
 
             _uiManager = GameObject.Instantiate(Resources.Load<GameObject>(UIManagerPath)).GetComponent<UIManager>();
+            GameObject.DontDestroyOnLoad(_uiManager);
         }
 
         private static Global _instance = null;

--- a/Assets/Scripts/Core/UISystem/UIManager.cs
+++ b/Assets/Scripts/Core/UISystem/UIManager.cs
@@ -36,11 +36,6 @@ namespace SuraSang
 
         public UIState State { get; private set; } = UIState.None;
 
-        private void Awake()
-        {
-            DontDestroyOnLoad(this);
-        }
-
         #region Get
 
         public T Get<T>() where T : UIModelBase


### PR DESCRIPTION
UI 매니저의 DontDestroyOnLoad 설정을 각 UI 매니저의 Awake 에서 처리하지 않고
Global에서 만드는 UI매니저에만 적용하도록 수정

UIManager는 Global에서 Instantiate 하기 때문에
현재 작업 중인 씬에 들어간 UIManager는 모두 삭제해야 함