### PR TITLE
분노 스킬 관련 버그들

### DIFF
--- a/Assets/Scripts/Monster/MonsterState/Anger/AngerDash.cs
+++ b/Assets/Scripts/Monster/MonsterState/Anger/AngerDash.cs
@@ -15,7 +15,7 @@ namespace SuraSang
 
         private float _radius;
 
-        public AngerDash(CharacterMove characterMove, Vector3 dir) : base(characterMove) 
+        public AngerDash(CharacterMove characterMove, Vector3 dir) : base(characterMove)
         {
             _dir = dir;
         }
@@ -28,7 +28,7 @@ namespace SuraSang
 
             _animator.SetTrigger("Attack");
 
-            _radius = _agent.radius;
+            _radius = _agent.radius * 2;
 
             AudioManager.Instance.SoundOneShot3D(AudioManager.Instance.SFX_M_Rush, _anger.transform);
         }
@@ -41,7 +41,7 @@ namespace SuraSang
 
             var capsulePoint1 = _anger.transform.position - Vector3.up * _agent.baseOffset;
             var capsulePoint2 = capsulePoint1 + Vector3.up * _agent.height;
-            
+
             var result = Physics.CapsuleCastAll(capsulePoint1, capsulePoint2,
                 _radius, _dir, _anger.DashSpeed * Time.deltaTime, _anger.DashCheckLayerMask);
 
@@ -50,8 +50,9 @@ namespace SuraSang
                 // 충돌 행동
                 Debug.Log(hit.transform.gameObject.name);
 
-                if(hit.transform.gameObject.tag == "Player")
+                if (hit.transform.gameObject.tag == "Player")
                 {
+                    Debug.LogError("플레이어 맞음");
                     hit.transform.gameObject.GetComponent<Animator>().SetTrigger("Hit");
                 }
 

--- a/Assets/Scripts/Skill/AngerSkill.cs
+++ b/Assets/Scripts/Skill/AngerSkill.cs
@@ -12,7 +12,7 @@ namespace SuraSang
         public bool IsStopAble => _isStopAble;
         private bool _isStopAble = false;
 
-        private static readonly LayerMask CheckMask = ~LayerMask.GetMask("Player", "CameraArea");
+        private static readonly LayerMask CheckMask = LayerMask.GetMask("Default", "Wall", "Monster");
 
         private Player _player;
         private CharacterController _controller;


### PR DESCRIPTION
**플레이어 분노 스킬 체크 레이어 수정**

카메라 볼륨 용으로 세팅한 콜리전에 충돌하는 이슈가 있어
분노 스킬 체크 레이어를 더 명확하게 수정

나중에 씬에서 카메라 볼륨용 콜리전의 레이어를 수정해아 함

**적 분노 스킬 충돌 범위 수정**

충돌 반경을 agent radius의 2배로 수정